### PR TITLE
Update R322A_Bar-w3p70m1-4.krn

### DIFF
--- a/kern/R322A_Bar-w3p70m1-4.krn
+++ b/kern/R322A_Bar-w3p70m1-4.krn
@@ -6,14 +6,14 @@
 **kern	**dynam	**kern	**dynam	**kern	**dynam	**kern	**dynam	**kern	**dynam	**kern	**dynam	**kern	**dynam	**kern	**dynam	**kern	**dynam	**kern	**dynam	**kern
 *part11	*part11	*part10	*part10	*part9	*part9	*part8	*part8	*part7	*part7	*part6	*part6	*part5	*part5	*part4	*part4	*part3	*part3	*part2	*part2	*part1
 *staff11	*	*staff10	*	*staff9	*	*staff8	*	*staff7	*	*staff6	*	*staff5	*	*staff4	*	*staff3	*	*staff2	*	*staff1
-*I"Contrabass	*	*I"Violoncello	*	*I"Viola	*	*I"Violin II	*	*I"Violin I	*	*I"Timpani	*	*I"Horns in F III,IV	*	*I"Horns in F I,II	*	*I"Bassoons	*	*I"Clarinets in Bb	*	*I"Oboes
+*I"Contrabass	*	*I"Violoncello	*	*I"Viola	*	*I"Violin II	*	*I"Violin I	*	*I"Timpani	*	*I"Horns in F III.IV.	*	*I"Horns in F I.II.	*	*I"2 Bassoons	*	*I"2 Clarinets in Bb	*	*I"2 Oboes
 *I'Cb.	*	*I'Vc.	*	*I'Vla.	*	*I'Vln. II	*	*I'Vln. I	*	*I'Timp.	*	*I'Hn.	*	*I'Hn.	*	*I'Bsn.	*	*I'Cl.	*	*I'Ob.
 *clefF4	*	*clefF4	*	*clefC3	*	*clefG2	*	*clefG2	*	*clefF4	*	*clefG2	*	*clefG2	*	*clefF4	*	*clefG2	*	*clefG2
 *ITrd0c0	*	*	*	*	*	*	*	*	*	*	*	*ITrd4c7	*	*ITrd4c7	*	*	*	*ITrd1c2	*	*
 *k[]	*	*k[]	*	*k[]	*	*k[]	*	*k[]	*	*k[]	*	*k[b-]	*	*k[b-]	*	*k[]	*	*k[b-e-]	*	*k[]
 *	*	*	*	*	*	*	*	*	*	*	*	*	*	*	*	*	*	*	*	*
 *M3/4	*	*M3/4	*	*M3/4	*	*M3/4	*	*M3/4	*	*M3/4	*	*M3/4	*	*M3/4	*	*M3/4	*	*M3/4	*	*M3/4
-!	!	!	!	!	!	!	!	!LO:TX:t=[quarter]=160	!	!	!	!	!	!	!	!	!	!	!	!LO:TX:t=[quarter]=160
+!	!	!	!	!	!	!	!	!LO:TX:t=Presto ([half.]=92)	!	!	!	!	!	!	!	!	!	!	!	!LO:TX:t= Presto ([half.]=92)
 4r	.	4r	.	4r	.	4r	.	(12gL	p	4r	.	4r	.	4r	.	4r	.	4r	.	4r
 .	.	.	.	.	.	.	.	12a	.	.	.	.	.	.	.	.	.	.	.	.
 .	.	.	.	.	.	.	.	12bJ	.	.	.	.	.	.	.	.	.	.	.	.


### PR DESCRIPTION
tempo e metronome markings were changed from (quarter = 160) to [presto (dotted half = 92)]
instrument names changed to 2 oboes, 2 clarinets in Bb, 2 bassoons, Horns in F I.II., Horns in F III.IV. to match original
unable to correct the vertical alignment of "poco forte" for clarinets and bassoons
all transpositions look fine, including contrabass