### PR TITLE
Update R371_Str-w15p19m2-1h1m1-5.krn

### DIFF
--- a/kern/R371_Str-w15p19m2-1h1m1-5.krn
+++ b/kern/R371_Str-w15p19m2-1h1m1-5.krn
@@ -6,7 +6,7 @@
 **kern	**dynam	**kern	**dynam	**kern	**dynam	**kern	**kern	**dynam	**kern	**kern	**dynam	**kern	**dynam
 *part8	*part8	*part7	*part7	*part6	*part6	*part5	*part4	*part4	*part3	*part2	*part2	*part1	*part1
 *staff8	*	*staff7	*	*staff6	*	*staff5	*staff4	*	*staff3	*staff2	*	*staff1	*
-*I"Contrabass	*	*I"Violin I	*	*I"Bass Drum	*	*I"Cymbals	*I"Trombone	*	*I"Cornet in Bb*	*I"Bassoon	*	*I"Clarinet in Bb	*
+*I"Contrabass	*	*I"Violin	*	*I"Bass Drum	*	*I"Cymbals	*I"Trombone	*	*I"Cornet in Bb	*I"Bassoon	*	*I"Clarinet in Bb	*
 *I'Cb.	*	*I'Vln. I	*	*I'B. D.	*	*I'Cym.	*I'Tbn.	*	*I'Picc. Tpt.	*I'Bsn.	*	*I'Cl.	*
 *	*	*	*	*stria1	*	*stria1	*	*	*	*	*	*	*
 *clefF4	*	*clefG2	*	*clefX2	*	*clefX2	*clefF4	*	*clefG2	*clefF4	*	*clefG2	*
@@ -14,11 +14,11 @@
 *k[b-e-]	*	*k[b-e-]	*	*k[]	*	*k[]	*k[b-e-]	*	*k[b-e-]	*k[b-e-]	*	*k[b-e-]	*
 *B-:	*	*B-:	*	*C:	*	*C:	*B-:	*	*B-:	*B-:	*	*B-:	*
 *M5/8	*	*M5/8	*	*M5/8	*	*M5/8	*M5/8	*	*M5/8	*M5/8	*	*M5/8	*
-* The Suter example incorrectly lists this as piccolo trumpet	*	*	*	*	*	*	*	*	*	*	*	*	*
+*	*	*	*	*	*	*	*	*	*	*	*	*	*
 =1	=1	=1	=1	=1	=1	=1	=1	=1	=1	=1	=1	=1	=1
 !LO:TX:b:t=[f]	!	!LO:TX:b:t=[f]	!	!LO:TX:b:t=[f]	!	!LO:TX:b:t=[mf]	!LO:TX:b:t=[f]	!	!LO:TX:b:t=[sf]	!LO:TX:b:t=[ff]	!	!LO:TX:b:t=[ff]	!
-8D` 8f	.	8d` 8b- 8bb-	.	8Re/	.	8Re/	8BB-`	.	8bb-	8d	.	8bb-`	.
-!	!	!LO:TX:a:i:t=secco	!	!	!	!	!LO:TX:a:i:t=sub. meno	!	!	!LO:TX:b:i:t=sub. meno	!	!LO:TX:a:i:t=sub. meno	!
+8D` 8f	.	8d` 8b- 8bb-	.	8Re/	.	8Re	8BB-`	.	8bb-	8d	.	8bb-`	.
+!	!	!LO:TX:a:i:t=secco	!	!	!	!	!LO:TX:a:i:t=sub. meno f	!	!	!LO:TX:b:i:t=sub. meno f	!	!LO:TX:a:i:t=sub. meno f	!
 8r	.	8B-`L 8d	sf	8r	.	8r	8r	f	8r	8f'L	f	8B-'L	f
 !	!	!	!	!	!	!	!	!	!LO:TX:a:t=Solo	!	!	!	!
 4r	.	8B-` 8d	.	8r	.	8r	8r	.	8fffL	8f'	.	8B-'	.
@@ -28,7 +28,7 @@
 16r	.	.	.	.	.	.	.	.	.	.	.	.	.
 =2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2
 *M2/4	*	*M2/4	*	*M2/4	*	*M2/4	*M2/4	*	*M2/4	*M2/4	*	*M2/4	*
-!	!	!	!	!	!	!LO:TX:a:t=Caisse cl. grande taille = sans timbre, baguette à téteen capoe	!	!	!	!	!	!	!
+!	!	!	!	!	!	!LO:TX:a:t=Caisse cl. grande taille = sans timbre, baguette à téte en capoe	!	!	!	!	!	!	!
 8r	.	8B-` 8d	.	8r	.	4r	2r	.	(20eeeXLL	8f'	.	8B-'	.
 .	.	.	.	.	.	.	.	.	20fff	.	.	.	.
 .	.	.	.	.	.	.	.	.	20eee	.	.	.	.
@@ -37,10 +37,10 @@
 8FL	.	8r	.	8Re/	p <	.	.	.	.	8r	.	8r	.
 .	.	.	.	.	.	.	.	.	20ddd	.	.	.	.
 .	.	.	.	.	.	.	.	.	20bb-JJ)	.	.	.	.
-8B-J	.	8r	.	4r	[	8Re^/	.	.	[4ddd	8r	.	8r	.
+8B-J	.	8r	.	4r	[	8Re^	.	.	[4ddd	8r	.	8r	.
 8r	.	8B-`L 8d	.	.	.	8r	.	.	.	8f'L	.	8B-'L	.
 =3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3
-4r	.	8B-` 8d	.	2r	.	2r	2r	.	8dddL]	8f'	.	8B-'	.
+4r	.	8B-`L 8d	.	2r	.	2r	2r	.	8dddL]	8f'L	.	8B-'L	.
 .	.	8B-`J 8d	.	.	.	.	.	.	8fff	8f'J	.	8B-'J	.
 !LO:TX:a:t=arco	!	!	!	!	!	!	!	!	!	!	!	!	!
 16B-`	.	8r	.	.	.	.	.	.	8fff	8r'	.	8r'	.
@@ -51,13 +51,13 @@
 8FL	.	4r	.	8Re/	<	8r	2r	.	(20eeeXLL	4r	.	4r	.
 .	.	.	.	.	.	.	.	.	20fff	.	.	.	.
 .	.	.	.	.	.	.	.	.	20eee	.	.	.	.
-8B-J	.	.	.	4r	[	8Re^/	.	.	.	.	.	.	.
+8B-J	.	.	.	4r	[	8Re^	.	.	.	.	.	.	.
 .	.	.	.	.	.	.	.	.	20ddd	.	.	.	.
 .	.	.	.	.	.	.	.	.	20cccJJ)	.	.	.	.
 4r	.	8B-`L 8d	.	.	.	8r	.	.	(20dddLL	8f'L	.	8B-'L	.
 .	.	.	.	.	.	.	.	.	20eee	.	.	.	.
 .	.	.	.	.	.	.	.	.	20ddd	.	.	.	.
-.	.	8B-` 8d	.	8r	.	8r	.	.	.	8f'	.	8B-'	.
+.	.	8B-`J 8d	.	8r	.	8r	.	.	.	8f'J	.	8B-'J	.
 .	.	.	.	.	.	.	.	.	20ccc	.	.	.	.
 .	.	.	.	.	.	.	.	.	20ggJJ)	.	.	.	.
 =5	=5	=5	=5	=5	=5	=5	=5	=5	=5	=5	=5	=5	=5
@@ -71,7 +71,7 @@
 .	.	.	.	.	.	.	.	.	20ggJJ)	.	.	.	.
 !LO:TX:a:t=pizz.	!	!	!	!	!	!	!	!	!	!	!	!	!
 8r	.	8B-` 8d	.	8r	.	.	.	.	8bb-L	8f'	.	8B-'	.
-8F	.	8r	.	8Re/	< [	.	.	.	16bb-L	8r	.	8r	.
+8F	.	8r	.	8Re/	 [	.	.	.	16bb-L	8r	.	8r	.
 .	.	.	.	.	.	.	.	.	16ffJJ	.	.	.	.
 =	=	=	=	=	=	=	=	=	=	=	=	=	=
 *-	*-	*-	*-	*-	*-	*-	*-	*-	*-	*-	*-	*-	*-


### PR DESCRIPTION
1. deleted * from instrument name Cornet in Bb, but unable to delete proofreader's comment;
2. deleted I from instrument name Violin;
3. partially fixed beaming (unable to cross bars)
4. changed direction of 1st percussion stems to fix bad spacing of accents;
5. fixed text above 2nd percussion
6. deleted "cresc." (perc. 2.), but unable to add <;
7. included "f" after "sub. meno", but unable to delete dynamic f.